### PR TITLE
implement visited set in FindPath to prevent unbounded memory growth

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,13 +54,19 @@ func (b *BFSTree) FindPath(start string, end string) (path *Path, err error) {
 	var iter int
 	var paths []*Path
 
+	// track visited nodes; without this FindPath walks every simple path
+	visited := map[string]bool{start: true}
+
 	// Create start paths from origin node
 	for _, e := range b.fromNode(start) {
 		p := newPath(e)
 		if e.To() == end {
 			return p, nil
 		}
-		paths = append(paths, p)
+		if !visited[e.To()] {
+			visited[e.To()] = true
+			paths = append(paths, p)
+		}
 	}
 
 	for len(paths) > 0 {
@@ -80,9 +86,9 @@ func (b *BFSTree) FindPath(start string, end string) (path *Path, err error) {
 
 			// branch path for each child node
 			for _, e := range children {
-				// drop circular paths
-				if p.IsCircular(e) {
-					dbg("    dropped circular child: %s->%s\n", e.From(), e.To())
+				// drop already-visited nodes
+				if visited[e.To()] {
+					dbg("    dropped visited child: %s->%s\n", e.From(), e.To())
 					continue
 				}
 
@@ -93,6 +99,7 @@ func (b *BFSTree) FindPath(start string, end string) (path *Path, err error) {
 				if e.To() == end {
 					return np, nil
 				}
+				visited[e.To()] = true
 				newPaths = append(newPaths, np)
 			}
 		}
@@ -129,6 +136,8 @@ func (p *Path) Nodes() []string {
 
 // Return whether a given edge, if added, would result in
 // a circular or recursive path
+//
+// Deprecated: FindPath now uses a global visited set; kept for compatibility.
 func (p *Path) IsCircular(edge Edge) bool {
 	child := edge.To()
 	for _, e := range p.edges {

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,9 @@
 package bfstree_test
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/bcicen/bfstree"
 )
@@ -54,4 +56,36 @@ func TestFindNoPath(t *testing.T) {
 		t.Errorf("no error returned on missing path")
 	}
 	t.Logf("got expected error: %s", err)
+}
+
+// TestFindNoPathInDenseGraph guards against combinatorial path blowup: a densely
+// connected graph has super-linearly many simple paths between nodes. Without a
+// global visited set, FindPath enumerates all of them for an unreachable target
+// and never returns. The search must terminate with an error.
+func TestFindNoPathInDenseGraph(t *testing.T) {
+	const n = 300
+	var edges []bfstree.Edge
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i != j {
+				edges = append(edges, TestEdge{strconv.Itoa(i), strconv.Itoa(j)})
+			}
+		}
+	}
+	dense := bfstree.New(edges...)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := dense.FindPath("0", "unreachable")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Errorf("expected error for unreachable target")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("FindPath did not terminate: combinatorial path blowup on a dense graph")
+	}
 }


### PR DESCRIPTION
# Fix: combinatorial blowup / OOM in FindPath when nodes have multiple paths

## Problem

`FindPath` can exhaust all memory and never return when the target is
unreachable, as soon as some node is reachable by more than one path. Reachable
targets usually return early, so the issue stays hidden until a search fails.

## Cause

`FindPath` only prevents a node from repeating **within a single path**
(`IsCircular`); it keeps no global record of visited nodes. So when a node can
be reached by several routes, each route is branched and tracked separately. The
number of distinct paths then grows super-linearly (up to factorial), and every
path is stored as its own copy. This needs no directed cycle — a reconverging
DAG like `1->2, 1->3, 2->4, 3->4, ...` already yields 2^k paths. For an
unreachable target there is no early return, so it grows until OOM.

Minimal example: a small densely connected graph + a `FindPath` to a node that
isn't in it.

## Fix

Add a `visited` set so every node is expanded at most once. This turns the
search from "enumerate every path" (O(n!)) into a standard BFS (O(n + e)); an
unreachable target now returns `"no path found"` promptly with bounded memory.

The per-path `IsCircular` check is replaced by the `visited` lookup. `IsCircular`
itself is kept (deprecated) for backwards compatibility. Reachable targets are
unaffected — BFS still returns a shortest path.